### PR TITLE
Remove GoogleService-Info.plist from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+GoogleService-Info.plist


### PR DESCRIPTION
## Description
This PR removes GoogleService-Info.plist from the repository and adds it to .gitignore. This is a security improvement as Firebase configuration files should not be committed to public repositories.

## Changes
- Removed GoogleService-Info.plist from repository
- Added GoogleService-Info.plist to .gitignore

## Why
GoogleService-Info.plist contains sensitive Firebase configuration data that should be kept private.


